### PR TITLE
Change options separator from ',' to § and make it configurable

### DIFF
--- a/vault_resources.go
+++ b/vault_resources.go
@@ -56,7 +56,7 @@ func (r *VaultResources) Set(value string) error {
 
 	// step: extract any options
 	if len(items) > 2 {
-		optionSep := getEnv("VAULT_SIDEKICK_SEPARATOR", "§")
+		optionSep := getEnv("VAULT_SIDEKICK_OPTIONS_SEPARATOR", "§")
 		for _, x := range strings.Split(items[2], optionSep) {
 			kp := strings.Split(x, "=")
 			if len(kp) != 2 {

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -56,7 +56,8 @@ func (r *VaultResources) Set(value string) error {
 
 	// step: extract any options
 	if len(items) > 2 {
-		for _, x := range strings.Split(items[2], ",") {
+		optionSep := getEnv("VAULT_SIDEKICK_SEPARATOR", "§")
+		for _, x := range strings.Split(items[2], optionSep) {
 			kp := strings.Split(x, "=")
 			if len(kp) != 2 {
 				return fmt.Errorf("invalid resource option: %s, must be KEY=VALUE", x)


### PR DESCRIPTION
## Change options separator from ',' to § and make it configurable
At the moment `vault-sidekick` splits the options parameters on commas, which means that it's not possible to have commas in option values. This PR fixes this by making the default options separator a `§` character. This is configurable through an environment variable, `VAULT_SIDEKICK_OPTIONS_SEPARATOR`.


## Further Explanation
By default, asking Vault sidekick to watch and issue a Vault PKI cert looks something like this:

```
./vault-sidekick -cn=pki:pki/k8s_ca/issue/k8s_apiserver:common_name='my common name',update=10s
```

The format for the `-cn` argument is `resourceType:path:options` where` options` is a comma separates list of `K=V` pairs.  However, sometimes there's a need to send Vault options which include commas. E.g. with the above example, we might also want to provide a list of alternative names, like this:

```
./vault-sidekick -cn=pki:pki/k8s_ca/issue/k8s_apiserver:common_name='my common name',alt_names='my-name,another-name',update=10s
```

The problem with this is that `vault-sidekick` splits the options parameters on commas, which means that having commas within a KV pair means the options aren't parsed properly. Running the above command gives the error `invalid resource option: %s, must be KEY=VALUE`.

## Longer Term
In the longer term, I think `vault-sidekick` should accept a config file which describes what resource to watch. We can then come up with a more readable way of describing resources to watch.



