### PR TITLE
Add certchain output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ or domain within the resource e.g -cn=secret:secrets/myservice/${ENV}/config:fmt
 
 ## Output Formatting
 
-The following output formats are supported: json, yaml, ini, txt, cert, csv, bundle, bundlechain, env, credential, aws
+The following output formats are supported: json, yaml, ini, txt, cert, certchain, csv, bundle, env, credential, aws
 
 Using the following at the demo secrets
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ or domain within the resource e.g -cn=secret:secrets/myservice/${ENV}/config:fmt
 
 ## Output Formatting
 
-The following output formats are supported: json, yaml, ini, txt, cert, csv, bundle, env, credential, aws
+The following output formats are supported: json, yaml, ini, txt, cert, csv, bundle, bundlechain, env, credential, aws
 
 Using the following at the demo secrets
 
@@ -169,7 +169,7 @@ bundle format is very similar in the sense it similar takes the private key and 
 
 ## Resource Options
 
-- **file**: (filaname) by default all file are relative to the output directory specified and will have the name NAME.RESOURCE; the fn options allows you to switch names and paths to write the files
+- **file**: (filename) by default all file are relative to the output directory specified and will have the name NAME.RESOURCE; the fn options allows you to switch names and paths to write the files
 - **mode**: (mode) overrides the default file permissions of the secret from 0664
 - **create**: (create) create the resource
 - **update**: (update) override the lease time of this resource and get/renew a secret on the specified duration e.g 1m, 2d, 5m10s

--- a/formats.go
+++ b/formats.go
@@ -97,7 +97,7 @@ func writeCertificateBundleFile(filename string, data map[string]interface{}, mo
 	keyFile := fmt.Sprintf("%s-key.pem", filename)
 	caFile := fmt.Sprintf("%s-ca.pem", filename)
 	certFile := fmt.Sprintf("%s.pem", filename)
-	
+
 	bundle := fmt.Sprintf("%s\n\n%s\n\n%s", data["certificate"], data["issuing_ca"], data["private_key"])
 	key := fmt.Sprintf("%s\n", data["private_key"])
 	ca := fmt.Sprintf("%s\n", data["issuing_ca"])

--- a/formats.go
+++ b/formats.go
@@ -126,18 +126,18 @@ func writeCertificateBundleFile(filename string, data map[string]interface{}, mo
 	return nil
 }
 
-func writeCertificateBundleChainFile(filename string, data map[string]interface{}, mode os.FileMode) error {
-	bundleChainFile := fmt.Sprintf("%s-bundle-chain.pem", filename)
+func writeCertificateChainFile(filename string, data map[string]interface{}, mode os.FileMode) error {
+	certChainFile := fmt.Sprintf("%s-cert-chain.pem", filename)
 	keyFile := fmt.Sprintf("%s-key.pem", filename)
 	caFile := fmt.Sprintf("%s-ca.pem", filename)
 	certFile := fmt.Sprintf("%s.pem", filename)
 
-	bundleChain := fmt.Sprintf("%s\n\n%s", data["certificate"], data["issuing_ca"])
+	certChain := fmt.Sprintf("%s\n\n%s", data["certificate"], data["issuing_ca"])
 	key := fmt.Sprintf("%s\n", data["private_key"])
 	ca := fmt.Sprintf("%s\n", data["issuing_ca"])
 	certificate := fmt.Sprintf("%s\n", data["certificate"])
 
-	if err := writeFile(bundleChainFile, []byte(bundleChain), mode); err != nil {
+	if err := writeFile(certChainFile, []byte(certChain), mode); err != nil {
 		glog.Errorf("failed to write the bundle chain certificate file, error: %s", err)
 		return err
 	}

--- a/formats.go
+++ b/formats.go
@@ -98,6 +98,8 @@ func writeCertificateBundleFile(filename string, data map[string]interface{}, mo
 	caFile := fmt.Sprintf("%s-ca.pem", filename)
 	certFile := fmt.Sprintf("%s.pem", filename)
 
+
+
 	bundle := fmt.Sprintf("%s\n\n%s\n\n%s", data["certificate"], data["issuing_ca"], data["private_key"])
 	key := fmt.Sprintf("%s\n", data["private_key"])
 	ca := fmt.Sprintf("%s\n", data["issuing_ca"])
@@ -109,17 +111,52 @@ func writeCertificateBundleFile(filename string, data map[string]interface{}, mo
 	}
 
 	if err := writeFile(certFile, []byte(certificate), mode); err != nil {
-		glog.Errorf("failed to write the certificate file, errro: %s", err)
+		glog.Errorf("failed to write the certificate file, error: %s", err)
 		return err
 	}
 
 	if err := writeFile(caFile, []byte(ca), mode); err != nil {
-		glog.Errorf("failed to write the ca file, errro: %s", err)
+		glog.Errorf("failed to write the ca file, error: %s", err)
 		return err
 	}
 
 	if err := writeFile(keyFile, []byte(key), mode); err != nil {
-		glog.Errorf("failed to write the key file, errro: %s", err)
+		glog.Errorf("failed to write the key file, error: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func writeCertificateBundleChainFile(filename string, data map[string]interface{}, mode os.FileMode) error {
+	bundleChainFile := fmt.Sprintf("%s-bundle-chain.pem", filename)
+	keyFile := fmt.Sprintf("%s-key.pem", filename)
+	caFile := fmt.Sprintf("%s-ca.pem", filename)
+	certFile := fmt.Sprintf("%s.pem", filename)
+
+
+	bundleChain := fmt.Sprintf("%s\n\n%s", data["certificate"], data["issuing_ca"])
+	key := fmt.Sprintf("%s\n", data["private_key"])
+	ca := fmt.Sprintf("%s\n", data["issuing_ca"])
+	certificate := fmt.Sprintf("%s\n", data["certificate"])
+
+	if err := writeFile(bundleChainFile, []byte(bundleChain), mode); err != nil {
+		glog.Errorf("failed to write the bundle chain certificate file, error: %s", err)
+		return err
+	}
+
+	if err := writeFile(certFile, []byte(certificate), mode); err != nil {
+		glog.Errorf("failed to write the certificate file, error: %s", err)
+		return err
+	}
+
+	if err := writeFile(caFile, []byte(ca), mode); err != nil {
+		glog.Errorf("failed to write the ca file, error: %s", err)
+		return err
+	}
+
+	if err := writeFile(keyFile, []byte(key), mode); err != nil {
+		glog.Errorf("failed to write the key file, error: %s", err)
 		return err
 	}
 

--- a/formats.go
+++ b/formats.go
@@ -97,9 +97,7 @@ func writeCertificateBundleFile(filename string, data map[string]interface{}, mo
 	keyFile := fmt.Sprintf("%s-key.pem", filename)
 	caFile := fmt.Sprintf("%s-ca.pem", filename)
 	certFile := fmt.Sprintf("%s.pem", filename)
-
-
-
+	
 	bundle := fmt.Sprintf("%s\n\n%s\n\n%s", data["certificate"], data["issuing_ca"], data["private_key"])
 	key := fmt.Sprintf("%s\n", data["private_key"])
 	ca := fmt.Sprintf("%s\n", data["issuing_ca"])
@@ -133,7 +131,6 @@ func writeCertificateBundleChainFile(filename string, data map[string]interface{
 	keyFile := fmt.Sprintf("%s-key.pem", filename)
 	caFile := fmt.Sprintf("%s-ca.pem", filename)
 	certFile := fmt.Sprintf("%s.pem", filename)
-
 
 	bundleChain := fmt.Sprintf("%s\n\n%s", data["certificate"], data["issuing_ca"])
 	key := fmt.Sprintf("%s\n", data["private_key"])

--- a/utils.go
+++ b/utils.go
@@ -191,12 +191,12 @@ func processResource(rn *VaultResource, data map[string]interface{}) (err error)
 		err = writeEnvFile(filename, data, rn.fileMode)
 	case "cert":
 		err = writeCertificateFile(filename, data, rn.fileMode)
+	case "certchain":
+		err = writeCertificateChainFile(filename, data, rn.fileMode)
 	case "txt":
 		err = writeTxtFile(filename, data, rn.fileMode)
 	case "bundle":
 		err = writeCertificateBundleFile(filename, data, rn.fileMode)
-	case "bundlechain":
-		err = writeCertificateBundleChainFile(filename, data, rn.fileMode)
 	case "credential":
 		err = writeCredentialFile(filename, data, rn.fileMode)
 	case "template":

--- a/utils.go
+++ b/utils.go
@@ -195,6 +195,8 @@ func processResource(rn *VaultResource, data map[string]interface{}) (err error)
 		err = writeTxtFile(filename, data, rn.fileMode)
 	case "bundle":
 		err = writeCertificateBundleFile(filename, data, rn.fileMode)
+	case "bundlechain":
+		err = writeCertificateBundleChainFile(filename, data, rn.fileMode)
 	case "credential":
 		err = writeCredentialFile(filename, data, rn.fileMode)
 	case "template":

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	resourceFormatRegex = regexp.MustCompile("^(yaml|yml|json|env|ini|txt|cert|bundle|bundlechain|csv|template|credential|aws)$")
+	resourceFormatRegex = regexp.MustCompile("^(yaml|yml|json|env|ini|txt|cert|certchain|bundle|csv|template|credential|aws)$")
 
 	// a map of valid resource to retrieve from vault
 	validResources = map[string]bool{

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	resourceFormatRegex = regexp.MustCompile("^(yaml|yml|json|env|ini|txt|cert|bundle|csv|template|credential|aws)$")
+	resourceFormatRegex = regexp.MustCompile("^(yaml|yml|json|env|ini|txt|cert|bundle|bundlechain|csv|template|credential|aws)$")
 
 	// a map of valid resource to retrieve from vault
 	validResources = map[string]bool{


### PR DESCRIPTION
## Add certchain output format

This is similar to the `bundle` format, except the bundle file does not contain the private key. This is useful where we want to keep the private key in a separate file to the bundle, so that permissions can be granted to the bundle file without giving access to the private key.

Also fixes a few typos in the readme and in the existing `bundle` formatter.