### PR TITLE
config: allow to specify resources in a YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Usage of /vault-sidekick:
     	the full path to write resources or VAULT_OUTPUT (default "/etc/secrets")
   -renew-token
       renew vault token according to its ttl
+  -resources-yaml string
+    	a YAML file containing a list of resources to retrieve and monitor from vault
   -stats duration
     	the interval to produce statistics on the accessed resources (default 1h0m0s)
   -stderrthreshold value
@@ -68,8 +70,41 @@ It's also possible to specify most of the options as an env variable:
 * `VAULT_SIDEKICK_EXEC_TIMEOUT`: `exec-timeout`
 * `VAULT_SIDEKICK_ONE_SHOT`: `one-shot`
 * `VAULT_SIDEKICK_RENEW_TOKEN`: `renew-token`
+* `VAULT_SIDEKICK_RESOURCES_YAML`: `resources-yaml`
 * `VAULT_SIDEKICK_SKIP_TLS_VERIFY`: `tls-skip-verify`
 * `VAULT_SIDEKICK_STATS_INTERVAL`: `stats`
+
+The YAML file passed to the `-resources-yaml` option is formatted as an
+array of `VaultResource`s, where a `VaultResource` is defined in
+`vault_resource.go`.
+
+An example resources file may look like this:
+
+```
+- resource: pki
+  path: pki/k8s/issue/apiserver
+  options:
+    common_name: k8s apiserver
+    ip_sans: 127.0.0.1,10.250.0.1
+    alt_names: alt-name.example.com
+    ttl: 604800
+  format: certchain
+  update: 24h
+  maxjitter: 6h
+  execpath: /bin/command
+  filemode: 0600
+
+- resource: pki
+  path: pki/k8s/issue/scheduler
+  options:
+    common_name: system:kube-scheduler
+    ttl: 604800
+  format: certchain
+  update: 24h
+  maxjitter: 6h
+  execpath: /bin/command
+  filemode: 0600
+```
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Usage of /vault-sidekick:
     	comma-separated list of pattern=N settings for file-filtered logging
 ```
 
+It's also possible to specify most of the options as an env variable:
+
+* `AUTH_FILE`: `auth`
+* `AUTH_FORMAT`: `format`
+* `VAULT_ADDR`: `vault`
+* `VAULT_AUTH_METHOD`: (doesn't map to any vault-sidekick option)
+* `VAULT_OUTPUT`: `output`
+* `VAULT_SIDEKICK_CA_CERT`: `ca-cert`
+* `VAULT_SIDEKICK_DRY_RUN`: `dryrun`
+* `VAULT_SIDEKICK_EXEC_TIMEOUT`: `exec-timeout`
+* `VAULT_SIDEKICK_ONE_SHOT`: `one-shot`
+* `VAULT_SIDEKICK_RENEW_TOKEN`: `renew-token`
+* `VAULT_SIDEKICK_SKIP_TLS_VERIFY`: `tls-skip-verify`
+* `VAULT_SIDEKICK_STATS_INTERVAL`: `stats`
+
 ## Building
 
 There is a Makefile in the base repository, so assuming you have make and go: `$ make`

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -82,19 +83,49 @@ func init() {
 		Method: authMethod,
 	}
 
+	defaultRenewToken, err := strconv.ParseBool(getEnv("VAULT_SIDEKICK_RENEW_TOKEN", "false"))
+	if err != nil {
+		defaultRenewToken = false
+	}
+
+	defaultDryRun, err := strconv.ParseBool(getEnv("VAULT_SIDEKICK_DRY_RUN", "false"))
+	if err != nil {
+		defaultDryRun = false
+	}
+
+	defaultSkipTLSVerify, err := strconv.ParseBool(getEnv("VAULT_SIDEKICK_SKIP_TLS_VERIFY", "false"))
+	if err != nil {
+		defaultSkipTLSVerify = false
+	}
+
+	defaultStatsInterval, err := time.ParseDuration(getEnv("VAULT_SIDEKICK_STATS_INTERVAL", "1h"))
+	if err != nil {
+		defaultStatsInterval = time.Duration(1) * time.Hour
+	}
+
+	defaultExecTimeout, err := time.ParseDuration(getEnv("VAULT_SIDEKICK_EXEC_TIMEOUT", "60s"))
+	if err != nil {
+		defaultExecTimeout = time.Duration(60) * time.Second
+	}
+
+	defaultOneShot, err := strconv.ParseBool(getEnv("VAULT_SIDEKICK_ONE_SHOT", "false"))
+	if err != nil {
+		defaultOneShot = false
+	}
+
 	flag.StringVar(&options.vaultURL, "vault", getEnv("VAULT_ADDR", "https://127.0.0.1:8200"), "url the vault service or VAULT_ADDR")
 	flag.StringVar(&options.vaultAuthFile, "auth", getEnv("AUTH_FILE", ""), "a configuration file in json or yaml containing authentication arguments")
-	flag.BoolVar(&options.vaultRenewToken, "renew-token", false, "renew vault token according to its ttl")
+	flag.BoolVar(&options.vaultRenewToken, "renew-token", defaultRenewToken, "renew vault token according to its ttl")
 	flag.StringVar(&options.vaultAuthFileFormat, "format", getEnv("AUTH_FORMAT", "default"), "the auth file format")
 	flag.StringVar(&options.outputDir, "output", getEnv("VAULT_OUTPUT", "/etc/secrets"), "the full path to write resources or VAULT_OUTPUT")
-	flag.BoolVar(&options.dryRun, "dryrun", false, "perform a dry run, printing the content to screen")
-	flag.BoolVar(&options.skipTLSVerify, "tls-skip-verify", false, "whether to check and verify the vault service certificate")
-	flag.StringVar(&options.vaultCaFile, "ca-cert", "", "the path to the file container the CA used to verify the vault service")
-	flag.DurationVar(&options.statsInterval, "stats", time.Duration(1)*time.Hour, "the interval to produce statistics on the accessed resources")
-	flag.DurationVar(&options.execTimeout, "exec-timeout", time.Duration(60)*time.Second, "the timeout applied to commands on the exec option")
+	flag.BoolVar(&options.dryRun, "dryrun", defaultDryRun, "perform a dry run, printing the content to screen")
+	flag.BoolVar(&options.skipTLSVerify, "tls-skip-verify", defaultSkipTLSVerify, "whether to check and verify the vault service certificate")
+	flag.StringVar(&options.vaultCaFile, "ca-cert", getEnv("VAULT_SIDEKICK_CA_CERT", ""), "the path to the file container the CA used to verify the vault service")
+	flag.DurationVar(&options.statsInterval, "stats", defaultStatsInterval, "the interval to produce statistics on the accessed resources")
+	flag.DurationVar(&options.execTimeout, "exec-timeout", defaultExecTimeout, "the timeout applied to commands on the exec option")
 	flag.BoolVar(&options.showVersion, "version", false, "show the vault-sidekick version")
 	flag.Var(options.resources, "cn", "a resource to retrieve and monitor from vault")
-	flag.BoolVar(&options.oneShot, "one-shot", false, "retrieve resources from vault once and then exit")
+	flag.BoolVar(&options.oneShot, "one-shot", defaultOneShot, "retrieve resources from vault once and then exit")
 }
 
 // parseOptions validate the command line options and validates them

--- a/config.go
+++ b/config.go
@@ -159,6 +159,21 @@ func parseOptions() error {
 			return err
 		}
 
+		// Set resource's default vaules in case they are not
+		// set already
+		defaultResource := defaultVaultResource()
+		for _, resource := range *resources {
+			if resource.FileMode == 0 {
+				resource.FileMode = defaultResource.FileMode
+			}
+			if resource.Format == "" {
+				resource.Format = defaultResource.Format
+			}
+			if resource.Size == 0 {
+				resource.Size = defaultResource.Size
+			}
+		}
+
 		options.resources.items = append(options.resources.items, []*VaultResource(*resources)...)
 	}
 

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 						}
 					}
 				case EventTypeFailure:
-					if evt.Resource.maxRetries > 0 && evt.Resource.maxRetries < evt.Resource.retries {
+					if evt.Resource.MaxRetries > 0 && evt.Resource.MaxRetries < evt.Resource.Retries {
 						for i, r := range toProcess {
 							if evt.Resource == r {
 								toProcess = append(toProcess[:i], toProcess[i+1:]...)

--- a/utils.go
+++ b/utils.go
@@ -176,35 +176,35 @@ func processResource(rn *VaultResource, data map[string]interface{}) (err error)
 		filename = fmt.Sprintf("%s/%s", options.outputDir, filepath.Base(filename))
 	}
 	// step: format and write the file
-	switch rn.format {
+	switch rn.Format {
 	case "yaml":
 		fallthrough
 	case "yml":
-		err = writeYAMLFile(filename, data, rn.fileMode)
+		err = writeYAMLFile(filename, data, rn.FileMode)
 	case "json":
-		err = writeJSONFile(filename, data, rn.fileMode)
+		err = writeJSONFile(filename, data, rn.FileMode)
 	case "ini":
-		err = writeIniFile(filename, data, rn.fileMode)
+		err = writeIniFile(filename, data, rn.FileMode)
 	case "csv":
-		err = writeCSVFile(filename, data, rn.fileMode)
+		err = writeCSVFile(filename, data, rn.FileMode)
 	case "env":
-		err = writeEnvFile(filename, data, rn.fileMode)
+		err = writeEnvFile(filename, data, rn.FileMode)
 	case "cert":
-		err = writeCertificateFile(filename, data, rn.fileMode)
+		err = writeCertificateFile(filename, data, rn.FileMode)
 	case "certchain":
-		err = writeCertificateChainFile(filename, data, rn.fileMode)
+		err = writeCertificateChainFile(filename, data, rn.FileMode)
 	case "txt":
-		err = writeTxtFile(filename, data, rn.fileMode)
+		err = writeTxtFile(filename, data, rn.FileMode)
 	case "bundle":
-		err = writeCertificateBundleFile(filename, data, rn.fileMode)
+		err = writeCertificateBundleFile(filename, data, rn.FileMode)
 	case "credential":
-		err = writeCredentialFile(filename, data, rn.fileMode)
+		err = writeCredentialFile(filename, data, rn.FileMode)
 	case "template":
-		err = writeTemplateFile(filename, data, rn.fileMode, rn.templateFile)
+		err = writeTemplateFile(filename, data, rn.FileMode, rn.TemplateFile)
 	case "aws":
-		err = writeAwsCredentialFile(filename, data, rn.fileMode)
+		err = writeAwsCredentialFile(filename, data, rn.FileMode)
 	default:
-		return fmt.Errorf("unknown output format: %s", rn.format)
+		return fmt.Errorf("unknown output format: %s", rn.Format)
 	}
 	// step: check for an error
 	if err != nil {
@@ -212,9 +212,9 @@ func processResource(rn *VaultResource, data map[string]interface{}) (err error)
 	}
 
 	// step: check if we need to execute a command
-	if rn.execPath != "" {
-		glog.V(10).Infof("executing the command: %s for resource: %s", rn.execPath, filename)
-		parts := strings.Split(rn.execPath, " ")
+	if rn.ExecPath != "" {
+		glog.V(10).Infof("executing the command: %s for resource: %s", rn.ExecPath, filename)
+		parts := strings.Split(rn.ExecPath, " ")
 		var args []string
 		if len(parts) > 1 {
 			args = parts[1:]

--- a/vault_resource.go
+++ b/vault_resource.go
@@ -79,71 +79,71 @@ var (
 
 func defaultVaultResource() *VaultResource {
 	return &VaultResource{
-		fileMode:  os.FileMode(0664),
-		format:    "yaml",
-		options:   make(map[string]string, 0),
-		renewable: false,
-		revoked:   false,
-		size:      defaultSize,
+		FileMode:  os.FileMode(0664),
+		Format:    "yaml",
+		Options:   make(map[string]string, 0),
+		Renewable: false,
+		Revoked:   false,
+		Size:      defaultSize,
 	}
 }
 
 // VaultResource is the structure which defined a resource set from vault
 type VaultResource struct {
 	// the namespace of the resource
-	resource string
+	Resource string
 	// the name of the resource
-	path string
+	Path string
 	// the format of the resource
-	format string
+	Format string
 	// whether the resource should be renewed?
-	renewable bool
+	Renewable bool
 	// whether the resource should be revoked?
-	revoked bool
+	Revoked bool
 	// the revoke delay
-	revokeDelay time.Duration
+	RevokeDelay time.Duration
 	// the lease duration
-	update time.Duration
+	Update time.Duration
 	// whether the resource should be created?
-	create bool
+	Create bool
 	// the size of a secret to create
-	size int64
+	Size int64
 	// the filename to save the secret
-	filename string
+	Filename string
 	// the template file
-	templateFile string
+	TemplateFile string
 	// the path to an exec to run on a change
-	execPath string
+	ExecPath string
 	// additional options to the resource
-	options map[string]string
+	Options map[string]string
 	// the file permissions on the resource
-	fileMode os.FileMode
+	FileMode os.FileMode
 	// maxRetries is the maximum number of times this resource should be
 	// attempted to be retrieved from Vault before failing
-	maxRetries int
+	MaxRetries int
 	// retries is the number of times this resource has been retried since it
 	// last succeeded
-	retries int
+	Retries int
 	// maxJitter is the maximum jitter duration to use for this resource when
 	// performing renewals
-	maxJitter time.Duration
+	MaxJitter time.Duration
 }
 
 // GetFilename generates a resource filename by default the resource name and resource type, which
 // can override by the OPTION_FILENAME option
 func (r VaultResource) GetFilename() string {
-	if r.filename != "" {
-		return r.filename
+	if r.Filename != "" {
+		return r.Filename
 	}
 
-	return fmt.Sprintf("%s.%s", r.path, r.resource)
+	return fmt.Sprintf("%s.%s", r.Path, r.Resource)
 }
 
 // IsValid checks to see if the resource is valid
 func (r *VaultResource) IsValid() error {
 	// step: check the resource type
-	if _, found := validResources[r.resource]; !found {
-		return fmt.Errorf("unsupported resource type: %s", r.resource)
+	if _, found := validResources[r.Resource]; !found {
+		return fmt.Errorf("unsupported resource type: %s", r.Resource)
 	}
 
 	// step: check is have all the required options to this resource type
@@ -156,24 +156,24 @@ func (r *VaultResource) IsValid() error {
 
 // isValidResource validates the resource meets the requirements
 func (r *VaultResource) isValidResource() error {
-	switch r.resource {
+	switch r.Resource {
 	case "pki":
-		if _, found := r.options["common_name"]; !found {
+		if _, found := r.Options["common_name"]; !found {
 			return fmt.Errorf("pki resource requires a common name specified")
 		}
 	case "transit":
-		if _, found := r.options["ciphertext"]; !found {
+		if _, found := r.Options["ciphertext"]; !found {
 			return fmt.Errorf("transit requires a ciphertext option")
 		}
 	case "tpl":
-		if _, found := r.options[optionTemplatePath]; !found {
+		if _, found := r.Options[optionTemplatePath]; !found {
 			return fmt.Errorf("template resource requires a template path option")
 		}
 	case "ssh":
-		if _, found := r.options["public_key_path"]; !found {
+		if _, found := r.Options["public_key_path"]; !found {
 			return fmt.Errorf("ssh resource requires a public key file path specified")
 		}
-		if _, found := r.options["cert_type"]; !found {
+		if _, found := r.Options["cert_type"]; !found {
 			return fmt.Errorf("ssh resource requires cert_type to be either host or user")
 		}
 	}
@@ -183,9 +183,9 @@ func (r *VaultResource) isValidResource() error {
 
 // String returns a string representation of the struct
 func (r VaultResource) String() string {
-	str := fmt.Sprintf("type: %s, path: %s", r.resource, r.path)
-	if r.maxRetries > 0 {
-		str = fmt.Sprintf("%s, attempts: %d/%d", str, r.retries, r.maxRetries+1)
+	str := fmt.Sprintf("type: %s, path: %s", r.Resource, r.Path)
+	if r.MaxRetries > 0 {
+		str = fmt.Sprintf("%s, attempts: %d/%d", str, r.Retries, r.MaxRetries+1)
 	}
 	return str
 }

--- a/vault_resources.go
+++ b/vault_resources.go
@@ -50,9 +50,9 @@ func (r *VaultResources) Set(value string) error {
 	}
 
 	// step: extract the elements
-	rn.resource = items[0]
-	rn.path = items[1]
-	rn.options = make(map[string]string, 0)
+	rn.Resource = items[0]
+	rn.Path = items[1]
+	rn.Options = make(map[string]string, 0)
 
 	// step: extract any options
 	if len(items) > 2 {
@@ -82,71 +82,71 @@ func (r *VaultResources) Set(value string) error {
 				if err != nil {
 					return errors.New("invalid file permissions on resource")
 				}
-				rn.fileMode = os.FileMode(v)
+				rn.FileMode = os.FileMode(v)
 			case optionFormat:
 				if matched := resourceFormatRegex.MatchString(value); !matched {
 					return fmt.Errorf("unsupported output format: %s", value)
 				}
-				rn.format = value
+				rn.Format = value
 			case optionUpdate:
 				duration, err := time.ParseDuration(value)
 				if err != nil {
 					return fmt.Errorf("update option: %s is not value, should be a duration format", value)
 				}
-				rn.update = duration
+				rn.Update = duration
 			case optionRevoke:
 				choice, err := strconv.ParseBool(value)
 				if err != nil {
 					return fmt.Errorf("the revoke option: %s is invalid, should be a boolean", value)
 				}
-				rn.revoked = choice
+				rn.Revoked = choice
 			case optionsRevokeDelay:
 				duration, err := time.ParseDuration(value)
 				if err != nil {
 					return fmt.Errorf("the revoke delay option: %s is not value, should be a duration format", value)
 				}
-				rn.revokeDelay = duration
+				rn.RevokeDelay = duration
 			case optionRenewal:
 				choice, err := strconv.ParseBool(value)
 				if err != nil {
 					return fmt.Errorf("the renewal option: %s is invalid, should be a boolean", value)
 				}
-				rn.renewable = choice
+				rn.Renewable = choice
 			case optionCreate:
 				choice, err := strconv.ParseBool(value)
 				if err != nil {
 					return fmt.Errorf("the create option: %s is invalid, should be a boolean", value)
 				}
-				if rn.resource != "secret" {
+				if rn.Resource != "secret" {
 					return fmt.Errorf("the create option is only supported for 'cn=secret' at this time")
 				}
-				rn.create = choice
+				rn.Create = choice
 			case optionSize:
 				size, err := strconv.ParseInt(value, 10, 16)
 				if err != nil {
 					return fmt.Errorf("the size option: %s is invalid, should be an integer", value)
 				}
-				rn.size = size
+				rn.Size = size
 			case optionExec:
-				rn.execPath = value
+				rn.ExecPath = value
 			case optionFilename:
-				rn.filename = value
+				rn.Filename = value
 			case optionTemplatePath:
-				rn.templateFile = value
+				rn.TemplateFile = value
 			case optionMaxRetries:
 				maxRetries, err := strconv.ParseInt(value, 10, 32)
 				if err != nil {
 					return fmt.Errorf("the retries option: %s is invalid, should be an integer", value)
 				}
-				rn.maxRetries = int(maxRetries)
+				rn.MaxRetries = int(maxRetries)
 			case optionMaxJitter:
 				maxJitter, err := time.ParseDuration(value)
 				if err != nil {
 					return fmt.Errorf("the jitter option: %s is invalid, should be in duration format", value)
 				}
-				rn.maxJitter = maxJitter
+				rn.MaxJitter = maxJitter
 			default:
-				rn.options[name] = value
+				rn.Options[name] = value
 			}
 		}
 	}

--- a/watched_resource.go
+++ b/watched_resource.go
@@ -47,20 +47,20 @@ type watchedResource struct {
 func (r *watchedResource) notifyOnRenewal(ch chan *watchedResource) {
 	go func() {
 		// step: check if the resource has a pre-configured renewal time
-		r.renewalTime = r.resource.update
+		r.renewalTime = r.resource.Update
 		// step: if the answer is no, we set the notification between 80-95% of the lease time of the secret
 		if r.renewalTime <= 0 {
 			// if there is no lease time, we canout set a renewal, just fade into the background
 			if r.secret.LeaseDuration <= 0 {
-				glog.Warningf("resource: %s has no lease duration, no custom update set, so item will not be updated", r.resource.path)
+				glog.Warningf("resource: %s has no lease duration, no custom update set, so item will not be updated", r.resource.Path)
 				return
 			}
 			r.renewalTime = r.calculateRenewal()
 		}
-		if r.resource.maxJitter != 0 {
-			glog.V(4).Infof("using maxJitter (%s) to calculate renewal time", r.resource.maxJitter)
+		if r.resource.MaxJitter != 0 {
+			glog.V(4).Infof("using maxJitter (%s) to calculate renewal time", r.resource.MaxJitter)
 			r.renewalTime = time.Duration(getDurationWithin(
-				int((r.renewalTime-r.resource.maxJitter)/time.Second),
+				int((r.renewalTime-r.resource.MaxJitter)/time.Second),
 				int(r.renewalTime/time.Second),
 			))
 		}


### PR DESCRIPTION
#### config: allow to specify resources in a YAML file
This commit introduces a new config switch, `-resources-yaml`, which
allows to specify a YAML file containing the definition for the
resources that should be watched by vault-sidekick.

The YAML is formatted as an array of `VaultResource`s, where a
`VaultResource` is defined in `vault_resource.go`.

An example resources file may look like this:

This commit introduces a new config switch, `-resources-yaml`, which
allows to specify a YAML file containing the definition for the
resources that should be watched by vault-sidekick.

The YAML is formatted as an array of `VaultResource`s, where a
`VaultResource` is defined in `vault_resource.go`.

An example resources file may look like this:

    - resource: pki
      path: pki/k8s/issue/apiserver
      options:
        common_name: k8s apiserver
        ip_sans: 127.0.0.1,10.250.0.1
        alt_names: alt-name.example.com
        ttl: 604800
      format: certchain
      update: 24h
      maxjitter: 6h
      execpath: /opt/bin/restart_docker_container k8s_kube-apiserver_kube-apiserver
      filemode: 0600

    - resource: pki
      path: pki/k8s/issue/scheduler
      options:
        common_name: system:kube-scheduler
        ttl: 604800
      format: certchain
      update: 24h
      maxjitter: 6h
      execpath: /opt/bin/restart_docker_container k8s_kube-scheduler_kube-scheduler
      filemode: 0600

####  config: allow to specify options as env variables
This commit allows to specify the following vault-sidekick options as env variables:

* VAULT_SIDEKICK_RENEW_TOKEN
* VAULT_SIDEKICK_DRY_RUN
* VAULT_SIDEKICK_SKIP_TLS_VERIFY
* VAULT_SIDEKICK_STATS_INTERVAL
* VAULT_SIDEKICK_EXEC_TIMEOUT
* VAULT_SIDEKICK_ONE_SHOT
* VAULT_SIDEKICK_CA_CERT