### PR TITLE
 Use exp backoff to retry failed attempts to get a resource

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,17 +48,17 @@ func main() {
 	}
 	glog.Infof("starting the %s, %s", prog, version)
 
-	// step: create a client to vault
-	vault, err := NewVaultService(options.vaultURL)
-	if err != nil {
-		showUsage("unable to create the vault client: %s", err)
-	}
-
 	//  Don't initialise metrics in one-shot mode.
 	if options.oneShot {
 		glog.Infof("running in one-shot mode")
 	} else {
 		metrics.Init(options.vaultAuthOptions.RoleID, options.metricsPort)
+	}
+
+	// step: create a client to vault
+	vault, err := NewVaultService(options.vaultURL)
+	if err != nil {
+		showUsage("unable to create the vault client: %s", err)
 	}
 
 	// step: create a channel to receive events upon and add our resources for renewal

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -24,9 +24,9 @@ type collector struct {
 	resourceExpiry map[string]time.Time
 
 	// resource{Totals,Successes,Errors} tracks counts of renewals per resource ID, and whether they succeeded or failed.
-	resourceTotals    map[string]int
-	resourceSuccesses map[string]int
-	resourceErrors    map[string]int
+	resourceTotals    map[string]int64
+	resourceSuccesses map[string]int64
+	resourceErrors    map[string]int64
 
 	// token{Totals,Successes,Errors} tracks counts of authentication attempts, and whether they succeeded or failed.
 	tokenTotals    int64

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -8,13 +8,17 @@ import (
 )
 
 type collector struct {
-	role string
+	resourceExpiryMetric *prometheus.Desc
 
-	resourceExpiryMetric  *prometheus.Desc
 	resourceTotalMetric   *prometheus.Desc
 	resourceSuccessMetric *prometheus.Desc
 	resourceErrorsMetric  *prometheus.Desc
-	errorsMetric          *prometheus.Desc
+
+	tokenTotalMetric   *prometheus.Desc
+	tokenSuccessMetric *prometheus.Desc
+	tokenErrorsMetric  *prometheus.Desc
+
+	errorsMetric *prometheus.Desc
 
 	// resourceExpiry is a map from resource ID to the last observed expiry time of resource.
 	resourceExpiry map[string]time.Time
@@ -23,6 +27,11 @@ type collector struct {
 	resourceTotals    map[string]int
 	resourceSuccesses map[string]int
 	resourceErrors    map[string]int
+
+	// token{Totals,Successes,Errors} tracks counts of authentication attempts, and whether they succeeded or failed.
+	tokenTotals    int64
+	tokenSuccesses int64
+	tokenErrors    int64
 
 	// errors Tracks counts generic, non-resource related errors, by reason.
 	errors map[string]int
@@ -54,6 +63,24 @@ func (c *collector) ResourceError(resourceID string) {
 	c.metricsMutex.Unlock()
 }
 
+func (c *collector) TokenTotal() {
+	c.metricsMutex.Lock()
+	c.tokenTotals++
+	c.metricsMutex.Unlock()
+}
+
+func (c *collector) TokenSuccess() {
+	c.metricsMutex.Lock()
+	c.tokenSuccesses++
+	c.metricsMutex.Unlock()
+}
+
+func (c *collector) TokenError() {
+	c.metricsMutex.Lock()
+	c.tokenErrors++
+	c.metricsMutex.Unlock()
+}
+
 func (c *collector) Error(reason string) {
 	c.metricsMutex.Lock()
 	c.errors[reason]++
@@ -61,10 +88,20 @@ func (c *collector) Error(reason string) {
 }
 
 func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	// Expiry metric
 	ch <- c.resourceExpiryMetric
+
+	// Resource metrics
 	ch <- c.resourceTotalMetric
 	ch <- c.resourceSuccessMetric
 	ch <- c.resourceErrorsMetric
+
+	// Token metrics
+	ch <- c.tokenTotalMetric
+	ch <- c.tokenSuccessMetric
+	ch <- c.tokenErrorsMetric
+
+	// General errors metric
 	ch <- c.errorsMetric
 }
 
@@ -75,26 +112,30 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	now := time.Now()
 	for resourceID, expiry := range c.resourceExpiry {
 		ch <- prometheus.MustNewConstMetric(c.resourceExpiryMetric, prometheus.GaugeValue, expiry.Sub(now).Seconds(),
-			resourceID, c.role)
+			resourceID)
 	}
 
 	for resourceID, totalCount := range c.resourceTotals {
 		ch <- prometheus.MustNewConstMetric(c.resourceTotalMetric, prometheus.CounterValue, float64(totalCount),
-			resourceID, c.role)
+			resourceID)
 	}
 
 	for resourceID, successCount := range c.resourceSuccesses {
 		ch <- prometheus.MustNewConstMetric(c.resourceSuccessMetric, prometheus.CounterValue, float64(successCount),
-			resourceID, c.role)
+			resourceID)
 	}
 
 	for resourceID, errCount := range c.resourceErrors {
 		ch <- prometheus.MustNewConstMetric(c.resourceErrorsMetric, prometheus.CounterValue, float64(errCount),
-			resourceID, c.role)
+			resourceID)
 	}
+
+	ch <- prometheus.MustNewConstMetric(c.tokenTotalMetric, prometheus.CounterValue, float64(c.tokenTotals))
+	ch <- prometheus.MustNewConstMetric(c.tokenSuccessMetric, prometheus.CounterValue, float64(c.tokenSuccesses))
+	ch <- prometheus.MustNewConstMetric(c.tokenErrorsMetric, prometheus.CounterValue, float64(c.tokenErrors))
 
 	for reason, errCount := range c.errors {
 		ch <- prometheus.MustNewConstMetric(c.errorsMetric, prometheus.CounterValue, float64(errCount),
-			reason, c.role)
+			reason)
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,31 +19,48 @@ func Init(role string, metricsPort uint) {
 	collectorMutex.Lock()
 	defer collectorMutex.Unlock()
 
-	resourceAndRoleLabels := []string{"resource_id", "role"}
 	col = &collector{
 		resourceExpiryMetric: prometheus.NewDesc("vault_sidekick_certificate_expiry_gauge",
 			"vault_sidekick_certificate_expiry_gauge",
-			resourceAndRoleLabels,
+			[]string{"resource_id"},
 			nil,
 		),
+
 		resourceTotalMetric: prometheus.NewDesc("vault_sidekick_resource_total_counter",
 			"vault_sidekick_resource_total_counter",
-			resourceAndRoleLabels,
+			[]string{"resource_id"},
 			nil,
 		),
 		resourceSuccessMetric: prometheus.NewDesc("vault_sidekick_resource_success_counter",
 			"vault_sidekick_resource_success_counter",
-			resourceAndRoleLabels,
+			[]string{"resource_id"},
 			nil,
 		),
 		resourceErrorsMetric: prometheus.NewDesc("vault_sidekick_resource_error_counter",
 			"vault_sidekick_resource_error_counter",
-			resourceAndRoleLabels,
+			[]string{"resource_id"},
 			nil,
 		),
+
+		tokenTotalMetric: prometheus.NewDesc("vault_sidekick_token_total_counter",
+			"vault_sidekick_resource_total_counter",
+			nil,
+			nil,
+		),
+		tokenSuccessMetric: prometheus.NewDesc("vault_sidekick_token_success_counter",
+			"vault_sidekick_resource_success_counter",
+			nil,
+			nil,
+		),
+		tokenErrorsMetric: prometheus.NewDesc("vault_sidekick_token_error_counter",
+			"vault_sidekick_resource_error_counter",
+			nil,
+			nil,
+		),
+
 		errorsMetric: prometheus.NewDesc("vault_sidekick_error_counter",
 			"vault_sidekick_error_counter",
-			[]string{"error", "role"},
+			nil,
 			nil,
 		),
 
@@ -102,6 +119,35 @@ func ResourceError(resourceID string) {
 		return
 	}
 	col.ResourceError(resourceID)
+}
+
+func TokenTotal() {
+	collectorMutex.RLock()
+	defer collectorMutex.RUnlock()
+
+	if col == nil {
+		return
+	}
+	col.TokenTotal()
+}
+
+func TokenSuccess() {
+	collectorMutex.RLock()
+	defer collectorMutex.RUnlock()
+	if col == nil {
+		return
+	}
+	col.TokenSuccess()
+}
+
+func TokenError() {
+	collectorMutex.RLock()
+	defer collectorMutex.RUnlock()
+
+	if col == nil {
+		return
+	}
+	col.TokenError()
 }
 
 func Error(reason string) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -66,9 +66,9 @@ func Init(role string, metricsPort uint) {
 
 		resourceExpiry: make(map[string]time.Time),
 
-		resourceTotals:    make(map[string]int),
-		resourceSuccesses: make(map[string]int),
-		resourceErrors:    make(map[string]int),
+		resourceTotals:    make(map[string]int64),
+		resourceSuccesses: make(map[string]int64),
+		resourceErrors:    make(map[string]int64),
 
 		errors: make(map[string]int),
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -64,8 +64,6 @@ func Init(role string, metricsPort uint) {
 			nil,
 		),
 
-		role: role,
-
 		resourceExpiry: make(map[string]time.Time),
 
 		resourceTotals:    make(map[string]int),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -20,8 +20,8 @@ func Init(role string, metricsPort uint) {
 	defer collectorMutex.Unlock()
 
 	col = &collector{
-		resourceExpiryMetric: prometheus.NewDesc("vault_sidekick_certificate_expiry_gauge",
-			"vault_sidekick_certificate_expiry_gauge",
+		resourceExpiryMetric: prometheus.NewDesc("vault_sidekick_resource_expiry_gauge",
+			"vault_sidekick_resource_expiry_gauge",
 			[]string{"resource_id"},
 			nil,
 		),
@@ -43,17 +43,17 @@ func Init(role string, metricsPort uint) {
 		),
 
 		tokenTotalMetric: prometheus.NewDesc("vault_sidekick_token_total_counter",
-			"vault_sidekick_resource_total_counter",
+			"vault_sidekick_token_total_counter",
 			nil,
 			nil,
 		),
 		tokenSuccessMetric: prometheus.NewDesc("vault_sidekick_token_success_counter",
-			"vault_sidekick_resource_success_counter",
+			"vault_sidekick_token_success_counter",
 			nil,
 			nil,
 		),
 		tokenErrorsMetric: prometheus.NewDesc("vault_sidekick_token_error_counter",
-			"vault_sidekick_resource_error_counter",
+			"vault_sidekick_token_error_counter",
 			nil,
 			nil,
 		),

--- a/vault.go
+++ b/vault.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -451,10 +450,6 @@ func (r VaultService) get(rn *watchedResource) error {
 	}
 	// step: check the error if any
 	if err != nil {
-		if strings.Contains(err.Error(), "missing client token") {
-			// decision: until the rewrite, lets just exit for now
-			glog.Fatalf("the vault token is no longer valid, exitting, error: %s", err)
-		}
 		return err
 	}
 	if secret == nil && err == nil {

--- a/vault.go
+++ b/vault.go
@@ -156,7 +156,9 @@ func (r *VaultService) vaultServiceProcessor() {
 					metrics.ResourceError(x.resource.ID())
 					glog.Errorf("failed to retrieve the resource: %s from vault, error: %s", x.resource, err)
 					// reschedule the attempt for later
-					r.scheduleIn(x, retrieveChannel, x.calculateRetry())
+					retryDuration := x.calculateRetry()
+					glog.V(3).Infof("rescheduling next get attempt for resource: %s in %s", x.resource, retryDuration)
+					r.scheduleIn(x, retrieveChannel, retryDuration)
 					x.resource.Retries++
 					r.upstream(VaultEvent{
 						Resource: x.resource,
@@ -231,7 +233,9 @@ func (r *VaultService) vaultServiceProcessor() {
 						metrics.ResourceError(x.resource.ID())
 						glog.Errorf("failed to renew the resource: %s for renewal, error: %s", x.resource, err)
 						// reschedule the attempt for later
-						r.scheduleIn(x, renewChannel, x.calculateRetry())
+						retryDuration := x.calculateRetry()
+						glog.V(3).Infof("rescheduling next renew attempt for resource: %s in %s", x.resource, retryDuration)
+						r.scheduleIn(x, renewChannel, retryDuration)
 						x.resource.Retries++
 						r.upstream(VaultEvent{
 							Resource: x.resource,

--- a/vault.go
+++ b/vault.go
@@ -561,6 +561,7 @@ func newVaultClient(opts *config) (*api.Client, error) {
 				<-time.After(renewPeriod)
 
 				glog.Infof("attempting token refresh")
+				metrics.TokenTotal()
 				err = getVaultClientToken(client, opts)
 				if err != nil {
 					renewPeriod = renewPeriod / 2
@@ -574,8 +575,10 @@ func newVaultClient(opts *config) (*api.Client, error) {
 					}
 
 					glog.Warningf("error: failed to renew token, retrying in %v: %v", renewPeriod, err)
+					metrics.TokenError()
 					continue
 				}
+				metrics.TokenSuccess()
 
 				tokenttl, err = getVaultClientTokenTTL(client)
 				if err != nil {

--- a/vault.go
+++ b/vault.go
@@ -157,7 +157,7 @@ func (r *VaultService) vaultServiceProcessor() {
 					metrics.ResourceError(x.resource.ID())
 					glog.Errorf("failed to retrieve the resource: %s from vault, error: %s", x.resource, err)
 					// reschedule the attempt for later
-					r.scheduleIn(x, retrieveChannel, getDurationWithin(3, 10))
+					r.scheduleIn(x, retrieveChannel, x.calculateRetry())
 					x.resource.Retries++
 					r.upstream(VaultEvent{
 						Resource: x.resource,
@@ -232,7 +232,7 @@ func (r *VaultService) vaultServiceProcessor() {
 						metrics.ResourceError(x.resource.ID())
 						glog.Errorf("failed to renew the resource: %s for renewal, error: %s", x.resource, err)
 						// reschedule the attempt for later
-						r.scheduleIn(x, renewChannel, getDurationWithin(3, 10))
+						r.scheduleIn(x, renewChannel, x.calculateRetry())
 						x.resource.Retries++
 						r.upstream(VaultEvent{
 							Resource: x.resource,

--- a/watched_resource.go
+++ b/watched_resource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"math"
 	"time"
 
 	"github.com/golang/glog"
@@ -86,10 +85,15 @@ func (r watchedResource) calculateRenewal() time.Duration {
 // based on the number of attempts.
 // The maximum retry time is set to 1h.
 func (r watchedResource) calculateRetry() time.Duration {
+	var retryMaximum time.Duration
 	retryMinimum := 10 * time.Second
 
-	retryMaximum := time.Duration(math.Pow(float64(r.resource.Retries), 2)) * 10 * time.Second
-	if retryMaximum > 1*time.Hour {
+	switch r.resource.Retries {
+	case 0:
+		retryMaximum = 1 * time.Minute
+	case 1:
+		retryMaximum = 10 * time.Minute
+	default:
 		retryMaximum = 1 * time.Hour
 	}
 


### PR DESCRIPTION
#### Use exp backoff to retry failed attempts to get a resource
This commit changes vault-sidekick to use an algorithm based on
exponential backoff to calculate the time after which it should retry a
failed attempt to get or renew a resource.
The maximum retry time is set to 1h.

#### Keep retrying Vault authentication rather than panicking
Vault-sidekick uses a timeout equals to token TTL/2 to refresh a vault
token.
Whenever the refresh operation fails, the token refresh is rescheduled
with a timeout equals to half of the previous one (until the timeout
goes below 1 second).

This commit changes this logic so that vault-sidekick will retry
indefinitely to refresh a token rather than panicking when the timeout
is < 1s.
The minimum retry time is set to 30 seconds plus a variable jitter
between 0 and 15 seconds.

#### Don't panic when a get fails because of missing vault token
After changing the logic which deals with token refresh failures, this
commit changes the `get` method of the `Vault` object to not fail in
case the vault token in invalid (since it's still possible the token
will get successfully renewed in the future).