### PR TITLE
Fix a terrifying bug where we would steal events out the update channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,8 +65,10 @@ func main() {
 	updates := make(chan VaultEvent, 10)
 	vault.AddListener(updates)
 
+	expiryUpdates := make(chan VaultEvent, 10)
+	vault.AddListener(expiryUpdates)
 	// Start a background worker which listens for resource updates and reports expiry metrics.
-	go reportExpiryMetrics(updates)
+	go reportExpiryMetrics(expiryUpdates)
 
 	// step: create a channel to receive events and keep the metrics
 	// collector data in sync


### PR DESCRIPTION
As a result, files would never get written. The events were coopted for metrics.
Glad I noticed this when running in s101!