### PR TITLE
Resource process metrics for disk write and exec steps

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -42,6 +42,22 @@ func Init(role string, metricsPort uint) {
 			nil,
 		),
 
+		resourceProcessTotalMetric: prometheus.NewDesc("vault_sidekick_resource_process_total_counter",
+			"vault_sidekick_resource_process_total_counter",
+			[]string{"resource_id", "stage"},
+			nil,
+		),
+		resourceProcessSuccessMetric: prometheus.NewDesc("vault_sidekick_resource_process_success_counter",
+			"vault_sidekick_resource_process_",
+			[]string{"resource_id", "stage"},
+			nil,
+		),
+		resourceProcessErrorsMetric: prometheus.NewDesc("vault_sidekick_resource_process_error_counter",
+			"vault_sidekick_resource_process_",
+			[]string{"resource_id", "stage"},
+			nil,
+		),
+
 		tokenTotalMetric: prometheus.NewDesc("vault_sidekick_token_total_counter",
 			"vault_sidekick_token_total_counter",
 			nil,
@@ -69,6 +85,10 @@ func Init(role string, metricsPort uint) {
 		resourceTotals:    make(map[string]int64),
 		resourceSuccesses: make(map[string]int64),
 		resourceErrors:    make(map[string]int64),
+
+		resourceProcessTotals:    make(map[string]map[string]int64),
+		resourceProcessSuccesses: make(map[string]map[string]int64),
+		resourceProcessErrors:    make(map[string]map[string]int64),
 
 		errors: make(map[string]int),
 	}
@@ -117,6 +137,35 @@ func ResourceError(resourceID string) {
 		return
 	}
 	col.ResourceError(resourceID)
+}
+
+func ResourceProcessTotal(resourceID, stage string) {
+	collectorMutex.RLock()
+	defer collectorMutex.RUnlock()
+
+	if col == nil {
+		return
+	}
+	col.ResourceProcessTotal(resourceID, stage)
+}
+
+func ResourceProcessSuccess(resourceID, stage string) {
+	collectorMutex.RLock()
+	defer collectorMutex.RUnlock()
+	if col == nil {
+		return
+	}
+	col.ResourceProcessSuccess(resourceID, stage)
+}
+
+func ResourceProcessError(resourceID, stage string) {
+	collectorMutex.RLock()
+	defer collectorMutex.RUnlock()
+
+	if col == nil {
+		return
+	}
+	col.ResourceProcessError(resourceID, stage)
 }
 
 func TokenTotal() {


### PR DESCRIPTION
Record resource process metrics when writing to disk and exec'ing

The stage label determines whether a metric is for a "disk_write" or an
"Exec"

Define resource process metrics for total, success and errors

These metrics track succeses, errors and totals for when resources are
"processed". Processing resources is the step that happens after a resource
is fetched from Vault - the resource is written to disk, and then, if
there's an exec specified on the resource, the given command is executed.

The rationale behind these new metrics is to give visibility on when the 
disk write or exec parts of resources fails.