### PR TITLE
Use full CA chain instead of just the issuing CA

### DIFF
--- a/formats.go
+++ b/formats.go
@@ -134,7 +134,19 @@ func writeCertificateChainFile(filename string, data map[string]interface{}, mod
 	caFile := fmt.Sprintf("%s-ca.pem", filename)
 	certFile := fmt.Sprintf("%s.pem", filename)
 
-	certChain := fmt.Sprintf("%s\n\n%s", data["certificate"], data["issuing_ca"])
+	// the chain should be a slice so assert that the type is []interface
+	chain, ok := data["ca_chain"].([]interface{})
+	if !ok {
+		glog.Errorf("Could not find the ca_chain")
+		return errors.New("Could not find the ca_chain")
+	}
+
+	ca_chain := []string{}
+	for _, cert := range chain {
+		ca_chain = append(ca_chain, fmt.Sprintf("%s", cert))
+	}
+
+	certChain := fmt.Sprintf("%s\n\n%s", data["certificate"], strings.Join(ca_chain, "\n"))
 	key := fmt.Sprintf("%s\n", data["private_key"])
 	ca := fmt.Sprintf("%s\n", data["issuing_ca"])
 	certificate := fmt.Sprintf("%s\n", data["certificate"])


### PR DESCRIPTION
While trying to issue certificates for Kubernetes API Server using the new PKI I ran into an issue with cert chains.
In our case we have the following PKI tree:

```
Kubernetes Root CA
Kubernetes Intermediate CA
Kubernetes Issuing CA
apiserver certificate
```

The Root CA is trusted on each client so the apiserver needs to present the rest of the chain: Kubernetes Intermediate CA, Kubernetes Issuing CA and apiserver certificate.

While testing I've found that the apiserver only presents Kubernetes Issuing CA and apiserver certificate. This is because we only use `issuing_ca` returned by Vault instead of the whole `ca_chain`.

Attaching a sample Vault response

```json
❯ vault write pki/kubernetes/kubernetes-issuing-ca/2021-06-10/issue/apiserver common_name="k8s apiserver" alt_names="foo" exclude_cn_from_sans="true" -format=json
{
  "request_id": "41318e5c-914c-b46e-6dc3-e7bb21f0f58b",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "ca_chain": [
      "-----BEGIN CERTIFICATE-----\nMIIChzCCAg6gAwIBAgIUP6ZJjpyISzxqFM4i8dN0fgyYzVIwCgYIKoZIzj0EAwIw\nT06Q6lXv0Z\n-----END CERTIFICATE-----",
      "-----BEGIN CERTIFICATE-----\nMIICfjCCAgSgAwIBAgIQDJw+aUOZpjZt68MKzTSPoTAKBggqhkjOPQQDAjBsMQsw\nYncmMuK6UeGEDoBk8c4iWyil\n-----END CERTIFICATE-----"
    ],
    "certificate": "-----BEGIN CERTIFICATE-----\nMIIC2jCCAmCgAwIBAgIUGMS3Xm5WJjC8TjS9FNDoZueO6YUwCgYIKoZIzj0EAwIw\nbzELMAkGA1UEBhMCR0IxDzANBgNVBAcTBkxvbmRvbjEXMBUGA1UEChMOTW9uem8g\nVXXVD3qu67+f/5x1zdE=\n-----END CERTIFICATE-----",
    "expiration": 1623940336,
    "issuing_ca": "-----BEGIN CERTIFICATE-----\nMIIChzCCAg6gAwIBAgIUP6ZJjpyISzxqFM4i8dN0fgyYzVIwCgYIKoZIzj0EAwIw\nT06Q6lXv0Z\n-----END CERTIFICATE-----",
    "private_key": "...",
    "private_key_type": "ec",
    "serial_number": "18:c4:b7:5e:6e:56:26:30:bc:4e:34:bd:14:d0:e8:66:e7:8e:e9:85"
  },
  "warnings": null
}
```

You can see how this is not a problem if we only have a Root CA, Intermediate CA and end-entity certificate as `ca_chain` and `issuing_ca` would be equivalent.

This PR changes `certchain` format to include the whole chain.